### PR TITLE
[APIS-774] column name and table name should also support Encoding with given charset

### DIFF
--- a/Code/Src/CUBRIDCciInterface.cs
+++ b/Code/Src/CUBRIDCciInterface.cs
@@ -197,6 +197,7 @@ namespace CUBRID.Data.CUBRIDClient
 
     internal static class CciInterface
     {
+        const int MAX_LENGTH = 254;
         const string dll_name = @"cascci.dll";
         [DllImport(dll_name, EntryPoint = "cci_get_db_version", CharSet = CharSet.Ansi)]
         public static extern int cci_get_db_version(int con_handle, StringBuilder out_buf, int capacity);
@@ -266,7 +267,7 @@ namespace CUBRID.Data.CUBRIDClient
             int stmt_type = 0;
             int col_num = 0;
             int n;
-            byte[] name = new byte[254];
+            byte[] name = new byte[MAX_LENGTH];
 
             IntPtr pt = cci_get_result_info_internal(req_handle, ref stmt_type, ref col_num);
             ColumnMetaData[] item = new ColumnMetaData[col_num];
@@ -293,15 +294,15 @@ namespace CUBRID.Data.CUBRIDClient
                     data.Scale = tmp.scale;
                     data.Type = (CUBRIDDataType)tmp.ext_type;
 
-                    Marshal.Copy(tmp.col_name, name, 0, 254);
-                    for (n = 0; n < 254; n++) if (name[n] == 0) break;
+                    Marshal.Copy(tmp.col_name, name, 0, MAX_LENGTH);
+                    for (n = 0; n < MAX_LENGTH; n++) if (name[n] == 0) break;
                     if (conn.GetEncoding().Equals(Encoding.UTF8))
                         data.Name = Encoding.UTF8.GetString(name, 0, n);
                     else
                         data.Name = Encoding.Unicode.GetString(name, 0, n);
 
-                    Marshal.Copy(tmp.class_name, name, 0, 254);
-                    for (n = 0; n < 254; n++) if (name[n] == 0) break;
+                    Marshal.Copy(tmp.class_name, name, 0, MAX_LENGTH);
+                    for (n = 0; n < MAX_LENGTH; n++) if (name[n] == 0) break;
                     if (conn.GetEncoding().Equals(Encoding.UTF8))
                     {
                         data.RealName = Encoding.UTF8.GetString(name, 0, n);

--- a/Code/Src/CUBRIDCciInterface.cs
+++ b/Code/Src/CUBRIDCciInterface.cs
@@ -197,7 +197,7 @@ namespace CUBRID.Data.CUBRIDClient
 
     internal static class CciInterface
     {
-        const int MAX_LENGTH = 254;
+        const int MAX_TBALE_COLUMN_NAME_LENGTH = 254;
         const string dll_name = @"cascci.dll";
         [DllImport(dll_name, EntryPoint = "cci_get_db_version", CharSet = CharSet.Ansi)]
         public static extern int cci_get_db_version(int con_handle, StringBuilder out_buf, int capacity);
@@ -267,7 +267,7 @@ namespace CUBRID.Data.CUBRIDClient
             int stmt_type = 0;
             int col_num = 0;
             int n;
-            byte[] name = new byte[MAX_LENGTH];
+            byte[] name = new byte[MAX_TBALE_COLUMN_NAME_LENGTH];
 
             IntPtr pt = cci_get_result_info_internal(req_handle, ref stmt_type, ref col_num);
             ColumnMetaData[] item = new ColumnMetaData[col_num];
@@ -294,15 +294,15 @@ namespace CUBRID.Data.CUBRIDClient
                     data.Scale = tmp.scale;
                     data.Type = (CUBRIDDataType)tmp.ext_type;
 
-                    Marshal.Copy(tmp.col_name, name, 0, MAX_LENGTH);
-                    for (n = 0; n < MAX_LENGTH; n++) if (name[n] == 0) break;
+                    Marshal.Copy(tmp.col_name, name, 0, MAX_TBALE_COLUMN_NAME_LENGTH);
+                    for (n = 0; n < MAX_TBALE_COLUMN_NAME_LENGTH; n++) if (name[n] == 0) break;
                     if (conn.GetEncoding().Equals(Encoding.UTF8))
                         data.Name = Encoding.UTF8.GetString(name, 0, n);
                     else
                         data.Name = Encoding.Unicode.GetString(name, 0, n);
 
-                    Marshal.Copy(tmp.class_name, name, 0, MAX_LENGTH);
-                    for (n = 0; n < MAX_LENGTH; n++) if (name[n] == 0) break;
+                    Marshal.Copy(tmp.class_name, name, 0, MAX_TBALE_COLUMN_NAME_LENGTH);
+                    for (n = 0; n < MAX_TBALE_COLUMN_NAME_LENGTH; n++) if (name[n] == 0) break;
                     if (conn.GetEncoding().Equals(Encoding.UTF8))
                     {
                         data.RealName = Encoding.UTF8.GetString(name, 0, n);

--- a/Code/Src/CUBRIDCommand.cs
+++ b/Code/Src/CUBRIDCommand.cs
@@ -469,8 +469,9 @@ namespace CUBRID.Data.CUBRIDClient
 	      }
 
 	    //T_CCI_COL_INFO res;
-	    columnInfos = CciInterface.cci_get_result_info (handle);
-	    dataReader = new CUBRIDDataReader (this, handle, ret, columnInfos, ret);
+	    columnInfos = CciInterface.cci_get_result_info (conn, handle);
+
+        dataReader = new CUBRIDDataReader (this, handle, ret, columnInfos, ret);
 
 	    return dataReader;
     }
@@ -536,7 +537,7 @@ namespace CUBRID.Data.CUBRIDClient
         throw new CUBRIDException (err.err_msg);
       }
 
-      columnInfos = CciInterface.cci_get_result_info(handle);
+        columnInfos = CciInterface.cci_get_result_info(conn, handle);
 
         if (this.Parameters.Count > 0)
         {

--- a/Code/Src/CUBRIDDataReader.cs
+++ b/Code/Src/CUBRIDDataReader.cs
@@ -804,7 +804,7 @@ namespace CUBRID.Data.CUBRIDClient
       resultCount = CciInterface.cci_next_result(handle, ref err);
       if (resultCount >= 0)
       {
-          columnMetaData = CciInterface.cci_get_result_info(handle);
+          columnMetaData = CciInterface.cci_get_result_info(conn, handle);
           currentRow = 0;
           resultTuple = new ResultTuple(columnMetaData.Length);
           commandBehavior = CommandBehavior.Default;


### PR DESCRIPTION
The driver modified no to be broken Korean character set with UTF-8 in Table and Column name.

The ADO.Net driver was tested for 91 cases on cubrid 10.1 and 9.3.
The new version for this modification will be released to ftp.cubrid.org.

