### PR TITLE
[APIS-824] (ADO.NET) Version name was wrong set into Cubrid.data.dll.

### DIFF
--- a/Code/Src/Properties/AssemblyInfo.cs
+++ b/Code/Src/Properties/AssemblyInfo.cs
@@ -42,4 +42,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("14216B9E-54FA-4F23-9EB4-06C9A63E1AC5")]
 [assembly: AssemblyVersion("10.1.0")]
-[assembly: AssemblyFileVersion("10.1.0.0003")]
+[assembly: AssemblyFileVersion("10.1.0.0004")]


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/APIS-824

ADO.NET Driver version name was wrong into Cubrid.data.dll.
So, changed version.
(10.1.0.0003 -> 10.1.0.0004)